### PR TITLE
Switch to OpenJDK 8

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@ ci_user: ci_user
 ci_user_uid: 5013
 ci_user_group: ci_user
 ci_user_default_keychain: login.keychain
-cask_packages: ['java8']
+cask_packages: ['adoptopenjdk/openjdk/adoptopenjdk8']
 ruby_gems: ['fastlane', 'cocoapods']
 
 # Additional variables:


### PR DESCRIPTION
Oracle has removed all older JDK versions, so the Java8 cask is no longer available.
Since there are licensing issues with JDK11+ switch to OpenJDK.