### PR TITLE
Install Homebrew with new bash install script

### DIFF
--- a/files/homebrew.sh
+++ b/files/homebrew.sh
@@ -4,6 +4,6 @@ USER=$1
 PASS=$2
 
 echo $PASS | sudo -S su $USER
-echo '' | ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+echo '' | /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
 exit $?


### PR DESCRIPTION
This gets rid of the deprecation warning from the Ruby script