### PR TITLE
Update 'Installing homebrew packages'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,8 +59,7 @@
 
 - name: Installing homebrew packages
   homebrew:
-    name: "{{ item }}"
-  with_items: "{{ homebrew_packages }}"
+    name: "{{ homebrew_packages }}"
   when: homebrew_packages is defined
 
 - name: Installing node 10 LTS


### PR DESCRIPTION
This gets rid of deprecation message:

> [DEPRECATION WARNING]: Invoking "homebrew" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ item }}"`, please use `name: '{{ homebrew_packages }}'`
and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.